### PR TITLE
Validation of composite components

### DIFF
--- a/src/main/java/com/github/lukaszbudnik/gugis/GugisCreationException.java
+++ b/src/main/java/com/github/lukaszbudnik/gugis/GugisCreationException.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis;
+
+import java.util.List;
+
+public class GugisCreationException extends RuntimeException {
+
+    private final String detailedMessage;
+
+    public GugisCreationException(List<String> validationErrors) {
+        StringBuilder messageBuilder = new StringBuilder();
+        messageBuilder.append("The following creation errors were found:");
+        for (int i = 0; i < validationErrors.size(); i++) {
+            messageBuilder.append("\n\n");
+            messageBuilder.append(i + 1);
+            messageBuilder.append(") ");
+            messageBuilder.append(validationErrors.get(i));
+        }
+        fillInStackTrace();
+        detailedMessage = messageBuilder.toString();
+    }
+
+    public String getMessage() {
+        return detailedMessage;
+    }
+
+}

--- a/src/main/java/com/github/lukaszbudnik/gugis/NonValidatingGugisModule.java
+++ b/src/main/java/com/github/lukaszbudnik/gugis/NonValidatingGugisModule.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis;
+
+
+public class NonValidatingGugisModule extends GugisModule {
+    public NonValidatingGugisModule() {
+        super(false);
+    }
+}

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/BasicTest.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/BasicTest.java
@@ -9,7 +9,7 @@
  */
 package com.github.lukaszbudnik.gugis.test;
 
-import com.github.lukaszbudnik.gugis.GugisModule;
+import com.github.lukaszbudnik.gugis.NonValidatingGugisModule;
 import com.github.lukaszbudnik.gugis.test.helpers.*;
 import org.apache.onami.test.OnamiRunner;
 import org.apache.onami.test.annotation.GuiceModules;
@@ -23,7 +23,7 @@ import javax.inject.Inject;
 import java.util.Set;
 
 @RunWith(OnamiRunner.class)
-@GuiceModules(GugisModule.class)
+@GuiceModules(NonValidatingGugisModule.class)
 public class BasicTest {
 
     @Inject

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/DisabledAutodiscoveryManualDiscoveryTest.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/DisabledAutodiscoveryManualDiscoveryTest.java
@@ -9,7 +9,7 @@
  */
 package com.github.lukaszbudnik.gugis.test;
 
-import com.github.lukaszbudnik.gugis.GugisModule;
+import com.github.lukaszbudnik.gugis.NonValidatingGugisModule;
 import com.github.lukaszbudnik.gugis.test.helpers.NotificationService;
 import com.github.lukaszbudnik.gugis.test.helpers.NotificationService1Impl;
 import com.github.lukaszbudnik.gugis.test.helpers.NotificationServiceComposite;
@@ -47,7 +47,7 @@ public class DisabledAutodiscoveryManualDiscoveryTest {
                         binder.addBinding().to(NotificationService1Impl.class);
                     }
                 },
-                new GugisModule()
+                new NonValidatingGugisModule()
         };
     }
 

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/DisabledAutodiscoveryTest.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/DisabledAutodiscoveryTest.java
@@ -10,7 +10,7 @@
 package com.github.lukaszbudnik.gugis.test;
 
 import com.github.lukaszbudnik.gugis.GugisException;
-import com.github.lukaszbudnik.gugis.GugisModule;
+import com.github.lukaszbudnik.gugis.NonValidatingGugisModule;
 import com.github.lukaszbudnik.gugis.test.helpers.NotificationService1Impl;
 import com.github.lukaszbudnik.gugis.test.helpers.NotificationServiceComposite;
 import org.apache.onami.test.OnamiRunner;
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import javax.inject.Inject;
 
 @RunWith(OnamiRunner.class)
-@GuiceModules(GugisModule.class)
+@GuiceModules(NonValidatingGugisModule.class)
 public class DisabledAutodiscoveryTest {
 
     @Inject

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/ErrorHandlingTest.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/ErrorHandlingTest.java
@@ -10,7 +10,7 @@
 package com.github.lukaszbudnik.gugis.test;
 
 import com.github.lukaszbudnik.gugis.GugisException;
-import com.github.lukaszbudnik.gugis.GugisModule;
+import com.github.lukaszbudnik.gugis.NonValidatingGugisModule;
 import com.github.lukaszbudnik.gugis.test.helpers.QueueService;
 import com.github.lukaszbudnik.gugis.test.helpers.QueueService1Impl;
 import com.github.lukaszbudnik.gugis.test.helpers.QueueService2Impl;
@@ -27,7 +27,7 @@ import javax.inject.Inject;
 import java.util.Set;
 
 @RunWith(OnamiRunner.class)
-@GuiceModules(GugisModule.class)
+@GuiceModules(NonValidatingGugisModule.class)
 public class ErrorHandlingTest {
 
     @Inject

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/ValidationTest.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/ValidationTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis.test;
+
+import com.github.lukaszbudnik.gugis.GugisModule;
+import com.github.lukaszbudnik.gugis.test.helpers.AggregatorServiceComposite;
+import com.github.lukaszbudnik.gugis.test.helpers.ReportServiceComposite;
+import com.github.lukaszbudnik.gugis.test.helpers.SplitterServiceComposite;
+import com.google.inject.CreationException;
+import com.google.inject.Guice;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ValidationTest {
+
+    @Test
+    public void shouldThrowGugisExceptionWhenImplementationsNotFound() {
+
+        try {
+            // fail fast, Guice injector will not be created at all
+            Guice.createInjector(new GugisModule());
+            Assert.fail("There should be an exception thrown by Gugis validation");
+        } catch (CreationException e) {
+            // the following errors should be detected:
+            // 1) ReportServiceComposite does not have any implementations at all
+            Assert.assertTrue(e.getCause().getMessage().contains("No implementations found for " + ReportServiceComposite.class));
+            // 2) AggregatorServiceComposite does not have @Primary implementations
+            Assert.assertTrue(e.getCause().getMessage().contains("Composite component " + AggregatorServiceComposite.class + " methods [public void aggregate()] marked with @Propagate(propagation = Propagation.PRIMARY) but no primary implementations found"));
+            // 3) SplitterServiceComposite does not have @Secondary implementations
+            Assert.assertTrue(e.getCause().getMessage().contains("Composite component " + SplitterServiceComposite.class + " methods [public void split()] marked with @Propagate(propagation = Propagation.SECONDARY) but no secondary implementations found"));
+        }
+
+    }
+
+}

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/AggregatorService.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/AggregatorService.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis.test.helpers;
+
+public interface AggregatorService {
+    void aggregate();
+}

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/AggregatorServiceComposite.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/AggregatorServiceComposite.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis.test.helpers;
+
+import com.github.lukaszbudnik.gugis.Composite;
+import com.github.lukaszbudnik.gugis.Propagate;
+import com.github.lukaszbudnik.gugis.Propagation;
+
+@Composite
+public class AggregatorServiceComposite implements AggregatorService {
+
+    @Propagate(propagation = Propagation.PRIMARY)
+    @Override
+    public void aggregate() {
+    }
+}

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/AggregatorServiceImpl.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/AggregatorServiceImpl.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis.test.helpers;
+
+import com.github.lukaszbudnik.gugis.Secondary;
+
+@Secondary
+public class AggregatorServiceImpl implements AggregatorService {
+
+    @Override
+    public void aggregate() {
+    }
+}

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/ReportService.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/ReportService.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis.test.helpers;
+
+public interface ReportService {
+
+    int uploadReport(String report);
+
+    String downloadReport(int id);
+
+}

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/ReportServiceComposite.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/ReportServiceComposite.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis.test.helpers;
+
+import com.github.lukaszbudnik.gugis.Composite;
+import com.github.lukaszbudnik.gugis.Propagate;
+import com.github.lukaszbudnik.gugis.Propagation;
+
+import javax.inject.Singleton;
+
+@Composite
+@Singleton
+public class ReportServiceComposite implements ReportService {
+
+    @Propagate(propagation = Propagation.PRIMARY)
+    @Override
+    public int uploadReport(String report) {
+        return 0;
+    }
+
+    @Propagate(propagation = Propagation.SECONDARY)
+    @Override
+    public String downloadReport(int id) {
+        return null;
+    }
+
+}

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/SplitterService.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/SplitterService.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis.test.helpers;
+
+public interface SplitterService {
+    void split();
+}

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/SplitterServiceComposite.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/SplitterServiceComposite.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis.test.helpers;
+
+import com.github.lukaszbudnik.gugis.Composite;
+import com.github.lukaszbudnik.gugis.Propagate;
+import com.github.lukaszbudnik.gugis.Propagation;
+
+@Composite
+public class SplitterServiceComposite implements SplitterService {
+
+    @Propagate(propagation = Propagation.SECONDARY)
+    @Override
+    public void split() {
+    }
+}

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/SplitterServiceImpl.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/SplitterServiceImpl.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.gugis.test.helpers;
+
+import com.github.lukaszbudnik.gugis.Primary;
+
+@Primary
+public class SplitterServiceImpl implements SplitterService {
+
+    @Override
+    public void split() {
+    }
+}


### PR DESCRIPTION
At the moment there is no fail fast validation of composite components. 

For example if there is a method marked with propagation PRIMARY but there is no actual implementation marked with @Primary Gugis fails only when the method is called. 

Adding fail fast validation would save a lot of developers pain.
