### PR TITLE
allowFailure to be supported by RANDOM and FASTEST

### DIFF
--- a/src/test/java/com/github/lukaszbudnik/gugis/test/ErrorHandlingTest.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/ErrorHandlingTest.java
@@ -112,7 +112,7 @@ public class ErrorHandlingTest {
     }
 
     @Test
-    public void shouldSelectAlwaysPrimaryAsSecondaryThrowsException() {
+    public void shouldSelectAlwaysFirstImplAsSecondThrowsException() {
         Assert.assertFalse(primary1.wasCalled());
         Assert.assertFalse(primary2.wasCalled());
 
@@ -123,10 +123,16 @@ public class ErrorHandlingTest {
         for (int i = 0; i < 100; i++) {
             String result = queueServiceComposite.permissions();
 
-            Assert.assertTrue(primary1.wasCalled());
+            // primary1 throws exception and doesn't call called()
+            Assert.assertFalse(primary1.wasCalled());
+            // primary2 is executed fine
             Assert.assertTrue(primary2.wasCalled());
 
+            // result is taken from primary2
             Assert.assertEquals("usera:write;userb:read", result);
+
+            // reset test services
+            reset();
         }
     }
 

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/QueueService.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/QueueService.java
@@ -17,4 +17,8 @@ public interface QueueService {
 
     void delete(String item);
 
+    int stats();
+
+    String permissions();
+
 }

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/QueueService1Impl.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/QueueService1Impl.java
@@ -38,4 +38,22 @@ public class QueueService1Impl extends AbstractTestService implements QueueServi
         called();
         throw new RuntimeException(this.getClass().getCanonicalName());
     }
+
+    @Override
+    public int stats() {
+        try {
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+        }
+        log.trace("stats");
+        called();
+        return 123;
+    }
+
+    @Override
+    public String permissions() {
+        log.trace("permissions");
+        called();
+        throw new RuntimeException(this.getClass().getCanonicalName());
+    }
 }

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/QueueService1Impl.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/QueueService1Impl.java
@@ -53,7 +53,6 @@ public class QueueService1Impl extends AbstractTestService implements QueueServi
     @Override
     public String permissions() {
         log.trace("permissions");
-        called();
         throw new RuntimeException(this.getClass().getCanonicalName());
     }
 }

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/QueueService2Impl.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/QueueService2Impl.java
@@ -39,4 +39,18 @@ public class QueueService2Impl extends AbstractTestService implements QueueServi
         called();
         throw new RuntimeException(this.getClass().getCanonicalName());
     }
+
+    @Override
+    public int stats() {
+        log.trace("stats");
+        called();
+        throw new RuntimeException(this.getClass().getCanonicalName());
+    }
+
+    @Override
+    public String permissions() {
+        log.trace("permissions");
+        called();
+        return "usera:write;userb:read";
+    }
 }

--- a/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/QueueServiceComposite.java
+++ b/src/test/java/com/github/lukaszbudnik/gugis/test/helpers/QueueServiceComposite.java
@@ -11,6 +11,7 @@ package com.github.lukaszbudnik.gugis.test.helpers;
 
 import com.github.lukaszbudnik.gugis.Composite;
 import com.github.lukaszbudnik.gugis.Propagate;
+import com.github.lukaszbudnik.gugis.Propagation;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -31,5 +32,17 @@ public class QueueServiceComposite implements QueueService {
     @Propagate(allowFailure = true)
     @Override
     public void delete(String item) {
+    }
+
+    @Propagate(propagation = Propagation.FASTEST, allowFailure = true)
+    @Override
+    public int stats() {
+        return 0;
+    }
+
+    @Propagate(propagation = Propagation.RANDOM, allowFailure = true)
+    @Override
+    public String permissions() {
+        return null;
     }
 }


### PR DESCRIPTION
At the moment propagations RANDOM and FASTEST just relay on the random/fastest instance to complete. They ignore allowFailure parameter. If random/fastest implementation will throw an exception Gugis will also throw an exception.

Propagations RANDOM and FASTEST should support allowFailure just like the rest of propagations.
